### PR TITLE
Remove postfix from custom SEO title

### DIFF
--- a/src/SEO.php
+++ b/src/SEO.php
@@ -101,7 +101,7 @@ class SEO
         );
 
         if (!empty($this->values['record']['title'])) {
-            $title = $this->values['record']['title'] . $postfix;
+            $title = $this->values['record']['title'];
         } else if (!empty($this->values['inferred']['title'])) {
             $title = $this->values['inferred']['title'] . $postfix;
         } else {

--- a/twig/_seo.twig
+++ b/twig/_seo.twig
@@ -143,7 +143,7 @@
             update: function() {
 
                 if ($('#seofields-title').val() != "") {
-                  var title = $('#seofields-title').val() + this.titlepostfix;
+                  var title = $('#seofields-title').val();
                 } else {
                   var title = $('#' + this.titlefield).val() + this.titlepostfix;
                 }


### PR DESCRIPTION
If a user is going out of their way to set a custom SEO title, I think they'd like to have full control over the title (at least I do when I'm setting custom titles).

This removes the postfix only when the SEO title is set, so when using an inferred field or default title, the postfix is still... postfixed.
