### PR TITLE
Open graph uses language_TERRITORY

### DIFF
--- a/twig/_metatags.twig
+++ b/twig/_metatags.twig
@@ -1,7 +1,7 @@
 {% if description is not empty %}
 <meta name="description" content="{{ description }}"/>
 {% endif %}
-        <meta property="og:locale" content="{{ htmllang() }}" />
+        <meta property="og:locale" content="{{ app.config.get('general/locale') }}" />
         <meta property="og:type" content="website" />
         <meta property="og:title" content="{{ title }}" />
 {% if description is not empty %}


### PR DESCRIPTION
Open graph uses language_TERRITORY instead of language-TERRITORY like HTML does, see http://ogp.me/#optional
