### PR TITLE
Update SEO.php

### DIFF
--- a/src/SEO.php
+++ b/src/SEO.php
@@ -49,10 +49,10 @@ class SEO
                     $this->values['record'] = json_decode($record->values[$fieldname], true);
                 }
                 if (($titlefield == "") && in_array($fieldname, $this->config['fields']['title']) ) {
-                    $this->values['inferred']['title'] = $record->values[$fieldname];
+                    $this->values['inferred']['title'] = $titlefield = $record->values[$fieldname];
                 }
                 if (($descriptionfield == "") && in_array($fieldname, $this->config['fields']['description']) ) {
-                    $this->values['inferred']['description'] = $record->values[$fieldname];
+                    $this->values['inferred']['description'] = $descriptionfield = $record->values[$fieldname];
                 }
             }
         }


### PR DESCRIPTION
set title and description with the first not empty match from config fields, otherwise if the last is empty (say for example, body) then the inferred values are emptied and meta title and description turn into default
