### PR TITLE
Add elseif to look for imagelist fields as well

### DIFF
--- a/src/SEO.php
+++ b/src/SEO.php
@@ -193,6 +193,11 @@ class SEO
                     $image = $this->record->values[$fieldname];
                 }
                 break;
+            } elseif ($field['type'] == 'imagelist') {
+                if (isset($this->record->values[$fieldname][0]['filename'])) {
+                    $image = $this->record->values[$fieldname][0]['filename'];
+                }
+                break;
             }
         }
 


### PR DESCRIPTION
Adds an `elseif` statement to the `findImage()` method to check if images exist within an `imagelist`.  This is assigned to the `$image` variable and populates the `og:image` meta tag for social sharing.
