### PR TITLE
Makes field NULLable

### DIFF
--- a/Seo.php
+++ b/Seo.php
@@ -24,7 +24,7 @@ class SEOField implements FieldInterface
 
     public function getStorageOptions()
     {
-        return array('default' => null);
+        return array('default' => null, 'notnull' => false);
     }
 
 }


### PR DESCRIPTION
Otherwise SQLite will error when updating DB, and MySQL will also not properly use default of NULL (instead it will fallback to an empty string I believe)

Fixes #16 
