### PR TITLE
Adapting _metatags.twig (addition)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ the correct `<title>` tag and the meta- and OG-tags.
 
 By default, the output of the meta-tags is defined in the file `extensions/vendor/bobdenotter/seo/twig/_metatags.twig`. 
 If you'd like to configure this output, you shouldn't edit this file directly. If you do, 
-changes will be overwritten on subsequent updates of this extension. Instead, copy the 
-file `_metatags.twig` to your theme's folder, and the extension will pick it up from there. 
+changes will be overwritten on subsequent updates of this extension. 
+Instead, in `/app/config/extensions/seo.bobdenotter.yml` decomment the lines
+```templates:
+    meta: _metatags.twig
+```, and copy the file `_metatags.twig` to your theme's folder, and the extension will pick it up from there. 
 
 **Note:** This is a new extension, so the functionality is still pretty bare bones. What's there
 works well, but there is probably a lot of functionality to add, to improve search engine


### PR DESCRIPTION
Is this addition correct? This did only worked on my Bolt 3.1.4 after decommenting these lines.
