### PR TITLE
Update template rendering service

### DIFF
--- a/src/SEO.php
+++ b/src/SEO.php
@@ -234,7 +234,7 @@ class SEO
             'canonical'   => $this->app['resources']->getUrl('canonicalurl'),
         ];
 
-        $html = $this->app['render']->render($this->config['templates']['meta'], $vars);
+        $html = $this->app['twig']->render($this->config['templates']['meta'], $vars);
 
         return new \Twig_Markup($html, 'UTF-8');
     }


### PR DESCRIPTION
Fixes #37 
Updated the service used to render seo tags from ~render~ to _twig_. That way, only the desired piece of html is returned.