### PR TITLE
Corrected weird 'these...this' wording in config comment

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -6,7 +6,7 @@ title_separator: "|"
 title_postfix: ''
 
 # The length used for the title and meta description. Note that increasing these values
-# this will _not_ make them appear as longer snippets in Google.
+# will _not_ make them appear as longer snippets in Google.
 # Set a value (i.e. 255) for the `keywords_length`, to enable the meta keywords option.
 title_length: 70
 description_length: 156


### PR DESCRIPTION
Saying "these" on one line and "this" on the next sounds weird. Not a big deal, but I think it reads a lot better this way.