### PR TITLE
Added og:type meta tag support with default of "website". Fixes #22

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -24,6 +24,7 @@ fields:
 default:
     title: ""
     description: ""
+    ogtype: "website" # default og:type value.
 
 # Control who can view the more "scary" fields
 # allow:

--- a/src/SEO.php
+++ b/src/SEO.php
@@ -110,6 +110,12 @@ class SEO
             $this->values['default']['keywords'] = '';
         }
 
+        if (!empty($this->config['default']['ogtype'])) {
+            $this->values['default']['ogtype'] = $this->config['default']['ogtype'];
+        } else {
+            $this->values['default']['ogtype'] = '';
+        }
+
         if (!empty($this->config['meta_robots'])) {
             $this->values['default']['meta_robots'] = $this->config['meta_robots'];
         } else {
@@ -202,6 +208,28 @@ class SEO
     /**
      * @param Content $record
      *
+     * @return string
+     */
+    public function ogtype($record = null)
+    {
+        $this->initialize($record);
+
+        if (!empty($this->values['record']['ogtype'])) {
+            $ogtype = $this->values['record']['ogtype'];
+        } elseif (!empty($this->values['inferred']['ogtype'])) {
+            $ogtype = $this->values['inferred']['ogtype'];
+        } else {
+            $ogtype = $this->values['default']['ogtype'];
+        }
+
+        $ogtype = $this->cleanUp($ogtype);
+
+        return $ogtype;
+    }
+
+    /**
+     * @param Content $record
+     *
      * @return array
      */
     public function robots($record = null)
@@ -235,6 +263,7 @@ class SEO
             'image'       => $this->findImage(),
             'version'     => $this->version,
             'robots'      => $this->robots(),
+            'ogtype'      => $this->ogtype(),
             'canonical'   => $this->app['resources']->getUrl('canonicalurl'),
         ];
 

--- a/templates/_metatags.twig
+++ b/templates/_metatags.twig
@@ -5,7 +5,7 @@
 {% endif %}
 {% endif %}
         <meta property="og:locale" content="{{ htmllang()|replace({'-': '_'}) }}" />
-        <meta property="og:type" content="website" />
+        <meta property="og:type" content="{{ ogtype|default('website') }}" />
         <meta property="og:title" content="{{ title }}" />
 {% if description|default() is not empty %}
         <meta property="og:description" content="{{ description }}" />

--- a/templates/_seo_extension_field.twig
+++ b/templates/_seo_extension_field.twig
@@ -152,6 +152,18 @@
     </div>
     {% endif %}
 
+    {# og:type meta #}
+    <fieldset class="form-group">
+        <label for="seofields-ogtype" class="col-sm-3 main control-label">{{__("Open Graph Type")}}:</label>
+        <div class="col-sm-9">
+            <input class="form-control narrow" id="seofields-ogtype" maxlength="255" type="text" value="{{ seovalues.ogtype|default('') }}">
+        </div>
+    </fieldset>
+
+    <div class="postfix" style="margin-top: 8px; margin-bottom: 24px;">
+        <p>{{__('Use this to set the <tt>&lt;meta name="og:type"&gt;</tt>')}}. {{__("Leave blank for the default")}}.</p>
+    </div>
+
     <input type="hidden" name="{{name}}" id="{{key}}" value="">
 
     <script>
@@ -203,6 +215,7 @@
                     'shortlink': $('#seofields-shortlink').val(),
                     'canonical': $('#seofields-canonical').val(),
                     'robots': $('#seofields-robots').val(),
+                    'ogtype': $('#seofields-ogtype').val(),
                     'keywords': $('#seofields-keywords').val() }
 
                 $('#{{key}}').val( JSON.stringify(value) );


### PR DESCRIPTION
I can't pretend this is perfect. There are a vast number of [Open Graph](http://ogp.me/) meta tag properties, and I'm wondering if adding them individually, one by one, is the best way to go about it.

Regardless, this does seem to work. You can set the default `ogtype` value in config.yml, which will be used if there is no value set for the page. Note that if the default is empty and the page `ogtype` value is empty, the metatag will use its own "website" default.

![og-type-value](https://user-images.githubusercontent.com/8106227/31695672-0bcf16e8-b37a-11e7-9224-7c5258217f51.png)

I tried to follow the methodology of the other SEO tags as best I could, but some of it will probably never be utilized, or if it is it's not really 'tested'. (For example, the *inferred* values.)