### PR TITLE
Override canonical properly if overridden

### DIFF
--- a/src/SEO.php
+++ b/src/SEO.php
@@ -392,10 +392,12 @@ class SEO
                 }
                 $url = sprintf('%s%s', $paths['canonical'], $canonical);
                 $this->app['resources']->setUrl('canonicalurl', $url);
+                $this->app['canonical']->setOverride($url);
             } else {
 
                 // Absolute link, so we don't add the domain.
                 $this->app['resources']->setUrl('canonicalurl', $canonical);
+                $this->app['canonical']->setOverride($canonical);
             }
         }
     }


### PR DESCRIPTION
I am not sure if I'm doing _naughty_ stuff here. This will make canonicals to be overridden per record via the SEO extension.

I'm calling `setOverride` in [Bolt\Routing\Canonical](https://github.com/bolt/bolt/blob/3.4/src/Routing/Canonical.php).

Fixes #57