### PR TITLE
Make permissions work again

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -17,7 +17,7 @@ fields:
     title: ['title', 'name']
     description: ['introduction', 'teaser', 'description', 'body']
     keywords: []
-    image: ['image']    
+    image: ['image']
 
 # The default title and description. If these are left empty, the extension will use the
 # sitename and payoff, from the global config.yml
@@ -29,8 +29,9 @@ default:
 # Control who can view the more "scary" fields
 # allow:
 #    shortlink: [ chief-editor, admin, developer, root ]
-#    canonical: [ admin, developer, chief-editor, root ]
-#    robots: [ admin, developer, chief-editor, root ]
+#    canonical: [ chief-editor, admin, developer, root ]
+#    robots: [ chief-editor, admin, developer, root ]
+#    ogtype: [ chief-editor, admin, developer, root ]
 
 # The default option for the `<meta name="robots" />` tag. The available options are:
 # - `index, follow` - Index this page, follow the links on this page.

--- a/templates/_seo_extension_field.twig
+++ b/templates/_seo_extension_field.twig
@@ -49,6 +49,9 @@
     {% set seovalues = seovalues|merge({'robots': seoconfig.meta_robots|default("index, follow")})  %}
 {% endif %}
 
+{# show/hide fields #}
+{% set show = seoAllowedConfig() %}
+
 {#=== FIELDSET ============================================================================#}
 
     {# Seo Title #}
@@ -106,37 +109,32 @@
     </div>
     </fieldset>
 
-    {% if seoconfig.allowed.shortlink|default(true) %}
     {# Shortlink #}
-    <fieldset class="form-group">
+    <fieldset class="form-group"{% if not show.shortlink %} hidden{% endif %}>
         <label for="seofields-shortlink" class="col-sm-3 main control-label">{{__("Shortlink")}} ({{__("alias")}}):</label>
         <div class="col-sm-9">
             <input class="form-control narrow" id="seofields-shortlink" maxlength="255" type="text" value="{{ seovalues.shortlink|default('') }}">
         </div>
     </fieldset>
 
-    <div class="postfix" style="margin-top: 8px; margin-bottom: 24px;">
+    <div class="postfix" style="margin-top: 8px; margin-bottom: 24px;"{% if not show.shortlink %} hidden{% endif %}>
         <p>{{__("Use this to create an alias or shortlink to this record. Be sure to make it an absolute link, starting with a <tt>/</tt>")}}.</p>
     </div>
-    {% endif %}
 
-    {% if seoconfig.allowed.canonical|default(true) %}
     {# Canonical link #}
-    <fieldset class="form-group">
+    <fieldset class="form-group"{% if not show.canonical %} hidden{% endif %}>
         <label for="seofields-canonical" class="col-sm-3 main control-label">{{__("Canonical Link")}}:</label>
         <div class="col-sm-9">
             <input class="form-control narrow" id="seofields-canonical" maxlength="255" type="text" value="{{ seovalues.canonical|default('') }}">
         </div>
     </fieldset>
 
-    <div class="postfix" style="margin-top: 8px; margin-bottom: 24px;">
+    <div class="postfix" style="margin-top: 8px; margin-bottom: 24px;"{% if not show.canonical %} hidden{% endif %}>
         <p>{{__('Use this to override the <tt>&lt;link rel="canonical"&gt;</tt>')}}. {{__("Use with caution, and only if you know what you're doing")}}.</p>
     </div>
-    {% endif %}
 
-    {% if seoconfig.allowed.robots|default(true) %}
     {# Robots tag #}
-    <fieldset class="form-group">
+    <fieldset class="form-group"{% if not show.robots %} hidden{% endif %}>
         <label for="seofields-robots" class="col-sm-3 main control-label">{{__("Meta Robots Tag")}}:</label>
         <div class="col-sm-9">
             <select id="seofields-robots" class="narrow form-control pull-left">
@@ -147,20 +145,19 @@
         </div>
     </fieldset>
 
-    <div class="postfix" style="margin-top: 8px; margin-bottom: 24px;">
+    <div class="postfix" style="margin-top: 8px; margin-bottom: 24px;"{% if not show.robots %} hidden{% endif %}>
         <p>{{__('Use this to set the <tt>&lt;meta name="robots"&gt;</tt>')}}. {{__("Use with caution, and only if you know what you're doing")}}.</p>
     </div>
-    {% endif %}
 
     {# og:type meta #}
-    <fieldset class="form-group">
+    <fieldset class="form-group"{% if not show.ogtype %} hidden{% endif %}>
         <label for="seofields-ogtype" class="col-sm-3 main control-label">{{__("Open Graph Type")}}:</label>
         <div class="col-sm-9">
             <input class="form-control narrow" id="seofields-ogtype" maxlength="255" type="text" value="{{ seovalues.ogtype|default('') }}">
         </div>
     </fieldset>
 
-    <div class="postfix" style="margin-top: 8px; margin-bottom: 24px;">
+    <div class="postfix" style="margin-top: 8px; margin-bottom: 24px;"{% if not show.ogtype %} hidden{% endif %}>
         <p>{{__('Use this to set the <tt>&lt;meta name="og:type"&gt;</tt>')}}. {{__("Leave blank for the default")}}.</p>
     </div>
 


### PR DESCRIPTION
Fixes #48

I've ported the code that was removed from https://github.com/bobdenotter/seo/commit/0f4102b290491bfc56e35fe4255097f44e0f4039

So, that makes use of `\Bolt\Users` which says it will be deprecated for Bolt 4.0.

For the newer Bolt, we can't _just_ use `$app['users']` early. Too early means there is no current user, so I took the approach of making a permission check function for Twig.

Also, I noticed that when you'd remove a field block for user role A but show for role B, then a role A save would actually empty the fields. So instead of removing them from the HTML, I use the `hidden` instead (effectively `style="display: none;"`).