### PR TITLE
Update description length to match new Google standards

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -9,7 +9,7 @@ title_postfix: ''
 # will _not_ make them appear as longer snippets in Google.
 # Set a value (i.e. 255) for the `keywords_length`, to enable the meta keywords option.
 title_length: 70
-description_length: 156
+description_length: 350
 keywords_length: 0 #255
 
 # Default values to consider for the title, meta description and meta keywords

--- a/templates/_seo_extension_field.twig
+++ b/templates/_seo_extension_field.twig
@@ -63,7 +63,8 @@
     </fieldset>
 
     <div class="postfix" style="margin-top: 8px;">
-        <p>{{__("Will be used as the <tt>&lt;title&gt;</tt> and in search engines")}}. {{__("Limit the length to 70 characters")}}.</p>
+        <p>{{__("Will be used as the <tt>&lt;title&gt;</tt> and in search engines")}}. 
+        {{__("Limit the length to %s characters", {'%s': 70}) }}.</p>
     </div>
 
     {# Meta description #}
@@ -76,7 +77,7 @@
 
     <div class="postfix">
         <p>{{__('Will be used as the <tt>&lt;meta name="description"&gt;</tt>, and will show up in search engines')}}.
-           {{__("Limit the length to 350 characters")}}.</p>
+           {{__("Limit the length to %s characters", {'%s': 350}) }}.</p>
     </div>
 
     {% if keywords_length > 0 %}
@@ -90,7 +91,7 @@
 
     <div class="postfix">
         <p>{{__('Will be used as the <tt>&lt;meta name="keywords"&gt;</tt>, and will show up in <em>some</em> search engines. Use comma separated tags only')}}.
-           {{__("Limit the length to 255 characters")}}.</p>
+           {{__("Limit the length to %s characters", {'%s': 255}) }}.</p>
     </div>
     {% else %}
     <input type='hidden' id="seofields-keywords" value='{{ seovalues.keywords|default('') }}'>

--- a/templates/_seo_extension_field.twig
+++ b/templates/_seo_extension_field.twig
@@ -64,7 +64,7 @@
 
     <div class="postfix" style="margin-top: 8px;">
         <p>{{__("Will be used as the <tt>&lt;title&gt;</tt> and in search engines")}}. 
-        {{__("Limit the length to %s characters", {'%s': 70}) }}.</p>
+        {{__("Limit the length to %s characters", {'%s': title_length}) }}.</p>
     </div>
 
     {# Meta description #}
@@ -77,7 +77,7 @@
 
     <div class="postfix">
         <p>{{__('Will be used as the <tt>&lt;meta name="description"&gt;</tt>, and will show up in search engines')}}.
-           {{__("Limit the length to %s characters", {'%s': 350}) }}.</p>
+           {{__("Limit the length to %s characters", {'%s': description_length}) }}.</p>
     </div>
 
     {% if keywords_length > 0 %}
@@ -91,7 +91,7 @@
 
     <div class="postfix">
         <p>{{__('Will be used as the <tt>&lt;meta name="keywords"&gt;</tt>, and will show up in <em>some</em> search engines. Use comma separated tags only')}}.
-           {{__("Limit the length to %s characters", {'%s': 255}) }}.</p>
+           {{__("Limit the length to %s characters", {'%s': keywords_length}) }}.</p>
     </div>
     {% else %}
     <input type='hidden' id="seofields-keywords" value='{{ seovalues.keywords|default('') }}'>

--- a/templates/_seo_extension_field.twig
+++ b/templates/_seo_extension_field.twig
@@ -42,7 +42,7 @@
 
 {% set seovalues = context.content.get(contentkey)|default('')|json_decode|default([]) %}
 {% set title_length = seoconfig.title_length|default(70) %}
-{% set description_length = seoconfig.description_length|default(156) %}
+{% set description_length = seoconfig.description_length|default(350) %}
 {% set keywords_length = seoconfig.keywords_length|default(0) %}
 
 {% if seovalues.robots is not defined %}

--- a/templates/_seo_extension_field.twig
+++ b/templates/_seo_extension_field.twig
@@ -76,7 +76,7 @@
 
     <div class="postfix">
         <p>{{__('Will be used as the <tt>&lt;meta name="description"&gt;</tt>, and will show up in search engines')}}.
-           {{__("Limit the length to 156 characters")}}.</p>
+           {{__("Limit the length to 350 characters")}}.</p>
     </div>
 
     {% if keywords_length > 0 %}
@@ -202,9 +202,9 @@
                 var canonical = $('#seofields-canonical').val();
                 var robots = $('#seofields-robots').val();
 
-                $('#seosnippet .title').text( this.trimtext(title, {{70}}) );
+                $('#seosnippet .title').text( this.trimtext(title, {{ title_length }}) );
                 $('#seosnippet cite').text( this.hostname + link );
-                $('#seosnippet .excerpt').text( this.trimtext(description, 156) );
+                $('#seosnippet .excerpt').text( this.trimtext(description, {{ description_length }}) ); 
 
                 var value = {
                     'title': $('#seofields-title').val(),

--- a/translations/cs/seo.cs.yml
+++ b/translations/cs/seo.cs.yml
@@ -1,9 +1,8 @@
 "SEO Title": SEO titulek
 "Will be used as the <tt>&lt;title&gt;</tt> and in search engines": "Bude použito jako <tt>&lt;title&gt;</tt> a ve vyhledávačích"
-"Limit the length to 70 characters": Omezte délku na 70 znaků
 "Meta description": Meta popisek
 'Will be used as the <tt>&lt;meta name="description"&gt;</tt>, and will show up in search engines': 'Bude použito jako <tt>&lt;meta name="description"&gt;</tt>, a bude se ukazovat ve vyhledávačích'
-"Limit the length to 156 characters": Omezte délku na 156 znaků
+"Limit the length to %s characters": Omezte délku na %s znaků
 "Google snippet preview": Ukázka Google snippetu
 "Bolt SEO Extension": Bolt SEO rozšíření
 "Sitelink": Odkaz stránky

--- a/translations/en/seo.en.yml
+++ b/translations/en/seo.en.yml
@@ -1,9 +1,8 @@
 "SEO Title": SEO Title
 "Will be used as the <tt>&lt;title&gt;</tt> and in search engines": "Will be used as the <tt>&lt;title&gt;</tt> and in search engines"
-"Limit the length to 70 characters": Limit the length to 70 characters
 "Meta description": Meta description
 'Will be used as the <tt>&lt;meta name="description"&gt;</tt>, and will show up in search engines': 'Will be used as the <tt>&lt;meta name="description"&gt;</tt>, and will show up in search engines'
-"Limit the length to 156 characters": Limit the length to 156 characters
+"Limit the length to %s characters": Limit the length to %s characters
 "Google snippet preview": Google snippet preview
 "Bolt SEO Extension": Bolt SEO Extension
 "Sitelink": Sitelink

--- a/translations/fr/seo.fr.yml
+++ b/translations/fr/seo.fr.yml
@@ -1,9 +1,8 @@
 "SEO Title": Titre SEO
 "Will be used as the <tt>&lt;title&gt;</tt> and in search engines": "Sera utilisé comme balise <tt>&lt;title&gt;</tt> et titre des moteurs de recherche"
-"Limit the length to 70 characters": Longueur limitée à 70 caractères
 "Meta description": Description Meta
 'Will be used as the <tt>&lt;meta name="description"&gt;</tt>, and will show up in search engines': 'Sera utilisé comme <tt>&lt;meta name="description"&gt;</tt> et affiché dans les moteurs de recherche'
-"Limit the length to 156 characters": Longueur limitée à 156 caractères
+"Limit the length to %s characters": Longueur limitée à %s caractères
 "Google snippet preview": Prévisualisation du Google snippet
 "Bolt SEO Extension": Extension Bolt SEO
 "Sitelink": Sitelink

--- a/translations/nl/seo.nl.yml
+++ b/translations/nl/seo.nl.yml
@@ -1,9 +1,8 @@
 "SEO Title": SEO Titel
 "Will be used as the <tt>&lt;title&gt;</tt> and in search engines": "Wordt gebruikt als <tt>&lt;title&gt;</tt> en in zoekmachines"
-"Limit the length to 70 characters": Beperk de lengte tot 70 karakters
 "Meta description": Meta beschrijving
 'Will be used as the <tt>&lt;meta name="description"&gt;</tt>, and will show up in search engines': 'Wordt gebruikt als de <tt>&lt;meta name="description"&gt;</tt>, en zal getoond worden in zoekmachines'
-"Limit the length to 156 characters": Beperk de lengte tot 156 karakters
+"Limit the length to %s characters": Beperk de lengte tot %s karakters
 "Google snippet preview": Google snippet voorvertoning
 "Bolt SEO Extension": Bolt SEO Extensie
 "Sitelink": Sitelink

--- a/translations/sv/seo.sv.yml
+++ b/translations/sv/seo.sv.yml
@@ -1,9 +1,8 @@
 "SEO Title": SEO Titel
 "Will be used as the <tt>&lt;title&gt;</tt> and in search engines": "Kommer användas som <tt>&lt;title&gt;</tt> och i sökmotorer"
-"Limit the length to 70 characters": Se till att hålla längden under 70 tecken
 "Meta description": Meta beskrivning
 'Will be used as the <tt>&lt;meta name="description"&gt;</tt>, and will show up in search engines': 'Kommer användas som <tt>&lt;meta name="description"&gt;</tt>, och visas som beskrivning i sökmotorer'
-"Limit the length to 156 characters": "Se till att hålla längden under 156 tecken"
+"Limit the length to %s characters": "Se till att hålla längden under %s tecken"
 "Google snippet preview": Förhandsgranskning av sökresultat
 "Bolt SEO Extension": Bolt SEO Tilägg
 "Sitelink": Länk


### PR DESCRIPTION
Current sites show the description length is around 325 characters, with sometimes even exceeding to 350. Setting the SEO description to cut off at 350 makes sure we include as many characters as possible. 